### PR TITLE
Language based voice listener

### DIFF
--- a/frontend/src/components/ChatContainer.js
+++ b/frontend/src/components/ChatContainer.js
@@ -5,12 +5,13 @@ import {nameMap} from '../utils/constants'
 
 const ChatContainer = () => {
   const [messages, setMessages] = useState([{
-    content: 'Hello! How can I help you today?',
+    content: "Hi! 👋 ¡Hola! I'm your English-Español AI Tutor. How can I assist you today?",
     role: 'assistant',
     name: 'AI Tutor',
   }])
   const [input, setInput] = useState('')
   const [waitingForVoiceResponse, setWaitingForVoiceResponse] = useState(false)
+  const [language, setLanguage] = useState('en-US')
   const messagesEndRef = useRef(null)
   const socketRef = useRef(null)
 
@@ -72,7 +73,7 @@ const ChatContainer = () => {
     } else {
       resetTranscript()
       setWaitingForVoiceResponse(false)
-      SpeechRecognition.startListening({continuous: false})
+      SpeechRecognition.startListening({continuous: false, language})
     }
   }
 
@@ -236,6 +237,10 @@ const ChatContainer = () => {
         <div ref={messagesEndRef} />
       </div>
       <div className="input-area">
+        <select className='lang-select' value={language} onChange={(e) => setLanguage(e.target.value)}>
+          <option value="en-US">English (US)</option>
+          <option value="es-ES">Spanish (Spain)</option>
+        </select>
         <button
           className={`button-voice ${listening ? 'listening' : ''}`}
           onClick={listening ? stopListening : startListening}

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -110,3 +110,30 @@
 .button-voice:hover, .button-send:hover, .button-reset:hover {
   background-color: #FFC107;
 }
+
+.lang-select {
+  appearance: none; /* Remove default arrow */
+  background-color: #333;
+  color: #FFD700;
+  border: 1px solid #FFD700;
+  border-radius: 4px;
+  padding: 5px 10px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: border-color 0.3s ease, background-color 0.3s ease;
+
+  /* Custom arrow using background SVG */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="5"><path fill="%23FFD700" d="M0 0l5 5 5-5z"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 10px 5px;
+
+  &:hover {
+    background-color: #444;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: #FFC107;
+  }
+}


### PR DESCRIPTION
## Description
- Currently, the bot only supports English and Spanish. It should have a greeting in these two languages to let the user know in advance
- The default listener works in both English and Spanish. However, the user should have the option to set a voice listener according to their preference

## Changes
- Change to an ES-EN greeting 
- Add lang-based listener
- Add styles to match the default select element with the theme